### PR TITLE
Removed right-hand column text

### DIFF
--- a/views/cato/eligibility_company_type.html
+++ b/views/cato/eligibility_company_type.html
@@ -17,9 +17,7 @@
     </div>
 {{/pageContent}}
 
-{{$rightColumn}}
-{{>cato_accounts_aside_type1}}
-{{/rightColumn}}
+
 
 {{$pageScripts}}
 <script type="text/javascript">


### PR DESCRIPTION
Right-hand column text not needed on this screen - the downloadable templates should appear on the next screen: Does your company sell insurance?